### PR TITLE
Minor style adjustments

### DIFF
--- a/src/IconInput.vue
+++ b/src/IconInput.vue
@@ -181,6 +181,7 @@ export default {
       svg {
         height: 1rem;
         width: 1rem;
+        filter: brightness(0) invert(1);
       }
     }
   }

--- a/src/IconInput.vue
+++ b/src/IconInput.vue
@@ -177,6 +177,11 @@ export default {
       margin-inline-end: 0.5rem;
       height: 1rem;
       width: 1rem;
+
+      svg {
+        height: 1rem;
+        width: 1rem;
+      }
     }
   }
 


### PR DESCRIPTION
Hi Tobias,

thank you for this plugin and all your other Kirby plugins 🙌 

I made two minor improvements to the iconinput styles to fix the following two cases:

**1: Icons not fitting the parent container when width and height are greater than 1rem or icons not being in 1:1 ratio.**
Please take a look at the following screenshot. I've added a red background for the not fixed version so it's easier to spot the problem. You can see that the deviantart, discourse, and dochub icons are overflowing the parent container. See this [commit](https://github.com/tobimori/kirby-icon-field/commit/fccfc43cdd75f0a82a64ba4925da22e38c71d92d). 
<img width="551" alt="iconinput" src="https://github.com/tobimori/kirby-icon-field/assets/3532570/7261336a-4016-402a-ae05-44bc4a6af5fa">


**2: SVG icons with colors other than white or without any color information.** 
Currently all icons are displayed in the color defined in the SVG in fill or stroke attributes or even in inline styles. Depending on the color chosen there, the contrast in the panel is very poor. Some icons, such as those from [fontAwesome](https://github.com/FortAwesome/Font-Awesome/tree/6.x/svgs/brands), have no color information at all and are displayed in black. Since the Mulitselect dropdown is black too, you don't see these icons at all. I've added a CSS filter to convert everything to white no matter how the icon was styled originally. See this [commit](https://github.com/tobimori/kirby-icon-field/commit/7a11164e0955f555dfdd5b5d54cdcbf1cba1aa94) 