### PR TITLE
Caching: limit hashing to actually used parameters

### DIFF
--- a/index.php
+++ b/index.php
@@ -124,7 +124,7 @@ App::plugin('tobimori/icon-field', [
 				'options' => function () {
 					$kirby = kirby();
 					$data = [];
-					$hash = md5(serialize($this->props()));
+					$hash = md5(serialize(A::get($this->props(), ['folder', 'sprite', 'include', 'exclude'])));
 
 					// Return the cached data if available
 					if ($cache = $kirby->cache('tobimori.icon-field')->get($hash)) {


### PR DESCRIPTION
You've used all props to create the hash under which options are cached. These props also include value, which makes the field very slow for larger iconsets, most notably when saving (value changed with save -> Kirby requests new field -> cache is worthless).

By pulling only the values which are used in the cached options (folder, sprite, include, exclude), cached options now can be used regardless of other field settings that don't change what options are available.

For large(r) iconsets, the change is: from 2-4 seconds on save, now we're back at ~150ms (eyeballed over 20+ requests, no real benchmarks)